### PR TITLE
Fixes blog tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,9 +3,9 @@ name: 'NUCLEARKATIE'
 description: 'Katie is driven by two of the largest problems facing our world today: climate change and nuclear weapons.'
 meta_description: ''
 logo: 'assets/images/bitmap.png'
-favicon: 'assets/images/favicon.ico'
+favicon: 'assets/images/atoms.ico'
 baseurl:
-production_url: https://horace.netlify.com/
+production_url: https://nuclearkatie.github.io/
 disqus: 'nuclearkatie'
 #mailchimp_url: '//justgoodthemes.us3.list-manage.com/subscribe/post?u=78f1bab16028354caeb23aecd&amp;id=4a7330d117'
 cover_image: atomz.gif

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,7 +66,8 @@
                 <p class="site-info">
                     <a href="#">NUCLEARKATIE</a> &copy; 2019 . Horace theme by
                     <a target="_blank" href="https://justgoodthemes.com/">JustGoodThemes</a>. <br />
-                    Powered by <a target="_blank" href="https://jekyllrb.com/">Jekyll</a> and hosted on <a target="_blank" href="https://github.com/nuclearkatie/nuclearkatie.github.io">Github Pages</a>.
+                    Powered by <a target="_blank" href="https://jekyllrb.com/">Jekyll</a> and hosted on <a target="_blank" href="https://github.com/nuclearkatie/nuclearkatie.github.io">Github Pages</a>.<br />
+                    Notice a broken link or missing file? <a target="_blank" href="https://github.com/nuclearkatie/nuclearkatie.github.io/issues">Open an issue!</a>
                 </p>
                 <p class="back-to-top">
                     <a id="top-button" class="top-button" href="#page">

--- a/_posts/2017-08-14-ans-memberships.md
+++ b/_posts/2017-08-14-ans-memberships.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: ANS Student Director Says National & Student Section Memberships are both a Must
-description: ANS Student Director Says National & Student Section Memberships are both a Must (ANS Nuclear Cafe Post)
+title: ANS Student Director Says National & Student Section Memberships are both a Must &#40;ANS Nuclear Cafe Post&#41;
+description: ANS Student Director Says National &#38; Student Section Memberships are both a Must &#40;ANS Nuclear Cafe Post&#41;
 tags: [ANS Nuclear Cafe, education]
 featured_image_thumbnail: assets/images/ANS_logo.jpg
 ---
 
-By Katie Mummah. This article originally appeared on the <a href="http://ansnuclearcafe.org/2017/07/05/ans-student-director-says-national-student-section-memberships-are-both-a-must/#sthash.A5WXOcMM.LgrZ2Alu.dpbs">ANS Nuclear Cafe</a>
+This article originally appeared on the <a href="http://ansnuclearcafe.org/2017/07/05/ans-student-director-says-national-student-section-memberships-are-both-a-must/#sthash.A5WXOcMM.LgrZ2Alu.dpbs">ANS Nuclear Cafe</a>
 
 I am the new student director for the <a href="http://www.ans.org">American Nuclear Society</a>. I will be representing students on the <a href="http://http://www.ans.org/about/board/">ANS Board of Directors</a> for the next two years.
 

--- a/_posts/2017-11-01-students4nuclear.md
+++ b/_posts/2017-11-01-students4nuclear.md
@@ -1,7 +1,6 @@
 ---
 layout: post
-title: Want to Become a Nuclear Advocate? Join Pro-Nuclear Organizations, Make Connections, and Speak Up! (Students4Nuclear Feature)
-description: Want to Become a Nuclear Advocate? Join Pro-Nuclear Organizations, Make Connections, and Speak Up! (Students4Nuclear Post)
+title: Want to Become a Nuclear Advocate&#63; Join Pro-Nuclear Organizations, Make Connections, and Speak Up&#33; &#40;Students4Nuclear Feature&#41;
 tags: [Students4Nuclear, advocacy]
 featured_image_thumbnail: assets/images/savethenukes_crop.jpg
 ---

--- a/_posts/2018-01-22-ANS-scholarships.md
+++ b/_posts/2018-01-22-ANS-scholarships.md
@@ -1,12 +1,10 @@
 ---
 layout: post
-title: Students, Apply for ANS Scholarships!
-description: Students Apply for ANS Scholarships! (ANS Nuclear Cafe Post)
+title: Students, Apply for ANS Scholarships&#33; &#40;ANS Nuclear Cafe Post&#41;
+description: Students Apply for ANS Scholarships&#33; &#40;ANS Nuclear Cafe Post&#41;
 tags: [ANS Nuclear Cafe]
 featured_image_thumbnail: assets/images/SCHOLARSHIPS-apply.jpg
 ---
-
-By Katie Mummah, 01/22/2018
 
 This article originally appeared on the <a href="http://ansnuclearcafe.org/2018/01/22/students-apply-for-ans-scholarships/#sthash.exwMPTP5.dpbs">ANS Nuclear Cafe</a>
 

--- a/_posts/2018-03-01-katharine-way.md
+++ b/_posts/2018-03-01-katharine-way.md
@@ -1,12 +1,10 @@
 ---
 layout: post
-title: Dr. Katharine Way, Women's History Month
-description: Women’s History Month & Nuclear Physicist Katharine Way (ANS Nuclear Cafe Post)
+title: Dr. Katharine Way, Women&#39;s History Month &#40;ANS Nuclear Cafe Post&#41;
+description: Women&#39;s History Month &#38; Nuclear Physicist Katharine Way &#40;ANS Nuclear Cafe Post&#41;
 tags: [women, nuclear, history, ANS Nuclear Cafe]
 featured_image_thumbnail: assets/images/katharine_way_crop.png
 ---
-
-By Katie Mummah, 03/01/2018
 
 This article originally appeared on the <a href="http://ansnuclearcafe.org/2018/03/07/30594/#sthash.TVKbpr0R.dpbs">ANS Nuclear Cafe</a> to celebrate women's history month.
 

--- a/_posts/2018-03-20-rosalyn-sussman-yalow.md
+++ b/_posts/2018-03-20-rosalyn-sussman-yalow.md
@@ -1,12 +1,10 @@
 ---
 layout: post
-title: Dr. Rosalyn Sussman Yalow, Women's History Month
-description: Women’s History Month & Rosalyn Sussman Yalow (ANS Nuclear Cafe Post)
+title: Dr. Rosalyn Sussman Yalow, Women&#39;s History Month &#40;ANS Nuclear Cafe Post&#41;
+description: Women&#39;s History Month & Rosalyn Sussman Yalow &#40;ANS Nuclear Cafe Post&#41;
 tags: [women, nuclear, history, ANS Nuclear Cafe]
 featured_image_thumbnail: assets/images/rosalyn-sussman-yalow_crop.jpg
 ---
-
-By Katie Mummah, 03/20/2018
 
 This article originally appeared on the <a href="http://ansnuclearcafe.org/2018/03/20/womens-history-month-physicist-dr-rosalyn-sussman-yalow/#sthash.Fxz1ZbXn.dpbs">ANS Nuclear Cafe</a> to celebrate women's history month.
 

--- a/_posts/2018-03-29-elda-emma-anderson.md
+++ b/_posts/2018-03-29-elda-emma-anderson.md
@@ -1,12 +1,10 @@
 ---
 layout: post
-title: Dr. Elda Emma Anderson, Women's History Month
-description: Women’s History Month (ANS Nuclear Cafe Post)
+title: Dr. Elda Emma Anderson, Women&#39;s History Month &#40;ANS Nuclear Cafe Post&#41;
+description: Women&#39;s History Month &#40;ANS Nuclear Cafe Post&#41;
 tags: [women, nuclear, history, ANS Nuclear Cafe]
 featured_image_thumbnail: assets/images/hps_square.png
 ---
-
-By Katie Mummah
 
 This article originally appeared on the <a href="http://ansnuclearcafe.org/2018/03/29/as-womens-history-month-concludes-lets-meet-dr-elda-emma-anderson/#sthash.PWu546UD.dpbs">ANS Nuclear Cafe</a> to celebrate women's history month.
 

--- a/_posts/2019-02-08-green-new-deal-nuclear.md
+++ b/_posts/2019-02-08-green-new-deal-nuclear.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  The official Green New Deal resolution is here. What does it say about nuclear power?
+title:  The official Green New Deal resolution is here. What does it say about nuclear power&#63;
 tags: [ nuclear, energy, Green New Deal, politics, uwLSC432]
 featured_image_thumbnail: assets/images/aoc-gnd.jpg
 featured_image: assets/images/aoc-gnd.jpg

--- a/_posts/2019-02-27-grad-school-visit-weekend.md
+++ b/_posts/2019-02-27-grad-school-visit-weekend.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  Going on grad school visits soon? Follow these 6 tips to get the most out of your visit
+title:  Going on grad school visits soon&#63; Follow these 6 tips to get the most out of your visit
 tags: [ grad school, education ]
 featured_image_thumbnail: assets/images/posts/2019/university-cover.png
 featured_image: assets/images/posts/2019/university.jpg


### PR DESCRIPTION
Blog tag errors were caused by two issues:

- Production URL was not updated 
- Quotes in blog titles was preventing tag html pages from being generated correctly

These two commits address those issues